### PR TITLE
Envelope Fix to reach zero volume at the end of tone / sound

### DIFF
--- a/simpleTones.js
+++ b/simpleTones.js
@@ -193,6 +193,9 @@ var chord = {
 	'B': [493.9, 622.254, 739.989],
 	'Bm': [493.9, 587.330, 739.989]
 }
+
+const VOLUME_CURVE = [1.0, 0.61, 0.37, 0.22, 0.14, 0.08, 0.05, 0.0];
+
 //Primary function
 playTone = (frequency, type, duration) => {
 	if (type === undefined) {
@@ -225,7 +228,8 @@ playTone = (frequency, type, duration) => {
 	}
 	g.connect(context.destination);
 	o.start(0);
-	g.gain.exponentialRampToValueAtTime(0.0001,context.currentTime + duration);
+	//g.gain.exponentialRampToValueAtTime(0.0001,context.currentTime + duration);
+	g.gain.setValueCurveAtTime(VOLUME_CURVE, context.currentTime, duration);
 }
 
 //This function helps complete chords and should not be used by itself
@@ -237,7 +241,7 @@ completeChord = (frequency, type, duration) => {
 	osc.frequency.value = frequency;
 	gn.connect(context.destination);
 	osc.start(0);
-	gn.gain.exponentialRampToValueAtTime(0.0001,context.currentTime + duration);
+	gn.gain.setValueCurveAtTime(VOLUME_CURVE, context.currentTime, duration);
 }
 
 
@@ -257,7 +261,7 @@ for (var i = 3; i < arguments.length; i += 2) {
 	oscillatorNode.frequency.exponentialRampToValueAtTime(arguments[i], context.currentTime + arguments[i+1]);
 }
 	gainNode.gain.setValueAtTime(0.3, context.currentTime);
-	gainNode.gain.exponentialRampToValueAtTime(0.1, context.currentTime +  0.5);
+	gainNode.gain.setValueCurveAtTime(VOLUME_CURVE, context.currentTime, 2.0);
   
 	oscillatorNode.connect(gainNode);
 	gainNode.connect(context.destination);


### PR DESCRIPTION
The current volume envelope is implemented with `exponentialRampToValueAtTime(value, endTime)` which does not support `0` for the target `value`. That's why you can still hear a super quiet sound after a tone /  sound is played when using a `value > 0`.

The fix uses `setValueCurveAtTime(values, startTime, duration)` with a semi-exponential decay curve defined in `const VOLUME_CURVE`. This curve reaches zero and no more sound is audible.